### PR TITLE
Updated functions to accept custom variable types in the tbl_summary/tbl_svysummary object.

### DIFF
--- a/R/add_SMD.R
+++ b/R/add_SMD.R
@@ -39,28 +39,20 @@ add_SMD <- function(tbl, location = "label", ref_group = FALSE, ci = FALSE, deci
     summary_type <- tbl$meta_data$summary_type[which(tbl$meta_data$variable == variable)]
 
 
-    if (location == "label") {
+    if (location == "label" | (location == "level" & summary_type == "continuous2")) {
       output <- core_smd_function(data, is_weighted,
                                   location = location, ref_group = ref_group,
                                   ci = ci, decimals = decimals,
                                   ci_bracket = ci_bracket, ci_sep = ci_sep)
     } else { # location == "level"
-      if (summary_type == "continuous2") {
-        output <- core_smd_function(data, is_weighted,
-                                    location = location, ref_group = ref_group,
-                                    ci = ci, decimals = decimals,
-                                    ci_bracket = ci_bracket, ci_sep = ci_sep, return_empty = TRUE)
-      } else { # all other summary tyopes
-        execute_by_level <- function(data, level, is_weighted) {
-          data <- data %>% dplyr::mutate(variable = variable == level)
-          core_smd_function(data, is_weighted,
-                            location = location, ref_group = ref_group,
-                            ci = ci, decimals = decimals,
-                            ci_bracket = ci_bracket, ci_sep = ci_sep)
-        }
-        output <- purrr::map_dfr(levels, .f = ~ execute_by_level(data, .x, is_weighted))
+      execute_by_level <- function(data, level, is_weighted) {
+        data <- data %>% dplyr::mutate(variable = variable == level)
+        core_smd_function(data, is_weighted,
+                          location = location, ref_group = ref_group,
+                          ci = ci, decimals = decimals,
+                          ci_bracket = ci_bracket, ci_sep = ci_sep)
       }
-
+      output <- purrr::map_dfr(levels, .f = ~ execute_by_level(data, .x, is_weighted))
     }
     return(output)
   }

--- a/R/core_smd_function.R
+++ b/R/core_smd_function.R
@@ -11,7 +11,7 @@
 
 #### add_SMD(): Create the core functionality for taking the data and outputting the SMD results
 
-core_smd_function <- function(data, is_weighted, location, ref_group, ci, decimals, ci_bracket, ci_sep, return_empty = FALSE) {
+core_smd_function <- function(data, is_weighted, location, ref_group, ci, decimals, ci_bracket, ci_sep) {
   # MAKE A TABLE OF EVERY POSSIBLE COMBO OF TWO DIFFERENT GROUPS
   groups <- factor(unique(data$by))
   pairs <- expand.grid(groups, groups) %>%
@@ -63,7 +63,6 @@ core_smd_function <- function(data, is_weighted, location, ref_group, ci, decima
   calc_SMD <- purrr::possibly(.f = calc_SMD, otherwise = NA_character_)
 
   smd_estimates <- purrr::map_chr(data_subsets, ~ calc_SMD(., is_weighted, ci, decimals))
-  if (return_empty) { smd_estimates <- NA_character_ }
 
   # OUTPUT THE RESULTS
   tibble::tibble(comp = comparisons, smd = smd_estimates) %>%

--- a/R/core_smd_function.R
+++ b/R/core_smd_function.R
@@ -11,7 +11,7 @@
 
 #### add_SMD(): Create the core functionality for taking the data and outputting the SMD results
 
-core_smd_function <- function(data, is_weighted, location, ref_group, ci, decimals, ci_bracket, ci_sep) {
+core_smd_function <- function(data, is_weighted, location, ref_group, ci, decimals, ci_bracket, ci_sep, return_empty = FALSE) {
   # MAKE A TABLE OF EVERY POSSIBLE COMBO OF TWO DIFFERENT GROUPS
   groups <- factor(unique(data$by))
   pairs <- expand.grid(groups, groups) %>%
@@ -63,6 +63,7 @@ core_smd_function <- function(data, is_weighted, location, ref_group, ci, decima
   calc_SMD <- purrr::possibly(.f = calc_SMD, otherwise = NA_character_)
 
   smd_estimates <- purrr::map_chr(data_subsets, ~ calc_SMD(., is_weighted, ci, decimals))
+  if (return_empty) { smd_estimates <- NA_character_ }
 
   # OUTPUT THE RESULTS
   tibble::tibble(comp = comparisons, smd = smd_estimates) %>%

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ trial %>%
   add_SMD()
 ```
 
-<div id="phklopkrnj" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="ekxdpqwrmr" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -124,7 +124,7 @@ trial %>%
   add_SMD(location = "level")
 ```
 
-<div id="zqqcbsfivx" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="xiupewutef" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -215,7 +215,7 @@ trial %>%
   add_SMD(location = "both")
 ```
 
-<div id="cxrngvtrsp" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="ugroparier" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -299,7 +299,7 @@ trial %>%
   add_SMD(location = "level", ci = TRUE, decimals = 3)
 ```
 
-<div id="iiqpynjnrh" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="waqopkakvf" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -383,7 +383,7 @@ To change the formatting of the confidence intervals, use the
   add_SMD(location = "level", ci = TRUE, ci_bracket="[]", ci_sep=";")
 ```
 
-<div id="pmqrnfkgqf" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="pgcfcljnxw" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -482,7 +482,7 @@ trial %>% mutate(
   add_SMD(ref_group = TRUE)
 ```
 
-<div id="uhrdvjhhqa" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="ypiqdgjkqd" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -574,7 +574,7 @@ trial %>%
   tbl_summary(by = grade, include = c(trt, age, stage))
 ```
 
-<div id="ydtgogkyww" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="pfjzowcczo" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -646,7 +646,7 @@ trial %>%
   round_5_gtsummary()
 ```
 
-<div id="xfjwwpobaw" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="phvbiaoesq" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -722,7 +722,7 @@ weighted_trial %>%
   round_5_gtsummary()
 ```
 
-<div id="tarwjpgctl" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="htiukjfxbk" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ trial %>%
   add_SMD()
 ```
 
-<div id="ekxdpqwrmr" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="unucjimnaz" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -124,7 +124,7 @@ trial %>%
   add_SMD(location = "level")
 ```
 
-<div id="xiupewutef" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="jameladauj" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -215,7 +215,7 @@ trial %>%
   add_SMD(location = "both")
 ```
 
-<div id="ugroparier" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="shbbxfpmxz" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -299,7 +299,7 @@ trial %>%
   add_SMD(location = "level", ci = TRUE, decimals = 3)
 ```
 
-<div id="waqopkakvf" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="ivzijiwfiv" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -383,7 +383,7 @@ To change the formatting of the confidence intervals, use the
   add_SMD(location = "level", ci = TRUE, ci_bracket="[]", ci_sep=";")
 ```
 
-<div id="pgcfcljnxw" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="sztqzircsc" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -482,7 +482,7 @@ trial %>% mutate(
   add_SMD(ref_group = TRUE)
 ```
 
-<div id="ypiqdgjkqd" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="asstmysgbv" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -574,7 +574,7 @@ trial %>%
   tbl_summary(by = grade, include = c(trt, age, stage))
 ```
 
-<div id="pfjzowcczo" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="bqtbwoosup" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -646,7 +646,7 @@ trial %>%
   round_5_gtsummary()
 ```
 
-<div id="phvbiaoesq" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="fafzmuwiyc" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>
@@ -722,7 +722,7 @@ weighted_trial %>%
   round_5_gtsummary()
 ```
 
-<div id="htiukjfxbk" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="sixtvctdjj" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
   <thead>

--- a/man/add_SMD.Rd
+++ b/man/add_SMD.Rd
@@ -35,7 +35,7 @@ This function takes a tbl_summary or tbl_svysummary object as input and adds col
 [1]: Yang & Dalton (2012): A unified approach to measuring the effect size between two groups using SAS® (https://support.sas.com/resources/papers/proceedings12/335-2012.pdf)
 }
 \seealso{
-See \code{\link{tbl_summary}} and \code{\link{tbl_svysummary}}
+See \code{\link[gtsummary]{tbl_summary}} and \code{\link[gtsummary]{tbl_svysummary}}
 }
 \author{
 Zheer Kejlberg Al-Mashhadi


### PR DESCRIPTION
Previously made erros when dichotomous variables had their type set to "categorical" or when continuous vars had type "continuous2" due to changed number of rows. Now, add_SMD works for both level/label/both for these variable types.